### PR TITLE
chore(renovate): disable dashboard approval, fix validate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "format": "biome check --write .",
-    "renovate:validate": "pnpm dlx --package renovate renovate-config-validator --strict",
+    "renovate:validate": "CI=1 pnpm dlx --package renovate renovate-config-validator --strict",
     "precheck": "pnpm lint && pnpm typecheck && pnpm build && pnpm test && actionlint"
   },
   "dependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "timezone": "Asia/Tokyo",
   "schedule": ["before 6am on monday"],
   "dependencyDashboard": true,
+  "dependencyDashboardApproval": false,
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- `renovate.json`: `dependencyDashboardApproval: false` を明示。何か（Mend 側 or アカウント config）が approval gate を有効化していたのを上書きし、weekly schedule 内の自動起票＋devDeps automerge を本来の挙動に戻す
- `package.json`: `renovate:validate` を `CI=1 pnpm dlx ...` に変更。pnpm v10 のビルドスクリプト承認プロンプトで対話停止するのを回避

`CI=1 pnpm dlx --package renovate renovate-config-validator --strict` で検証済み（pass）。

Refs #30