### PR TITLE
fix(renovate): set mode=full to override Mend silent default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "timezone": "Asia/Tokyo",
   "schedule": ["before 6am on monday"],
   "dependencyDashboard": true,
-  "dependencyDashboardApproval": false,
+  "mode": "full",
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
Dashboard の Pending Approval gate の真因は Mend org-level Silent モード(All-repositories install のデフォルト dryRun=lookup)。per-repo config-as-code override として mode: full を設定し、効果のなかった dependencyDashboardApproval を置き換える。Refs #30