### PR TITLE
fix(renovate): override Mend-injected approval; validate TTY-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "format": "biome check --write .",
-    "renovate:validate": "CI=1 pnpm dlx --package renovate renovate-config-validator --strict",
+    "renovate:validate": "npm_config_ignore_scripts=true pnpm dlx --package renovate renovate-config-validator --strict",
     "precheck": "pnpm lint && pnpm typecheck && pnpm build && pnpm test && actionlint"
   },
   "dependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,11 @@
   },
   "packageRules": [
     {
+      "description": "Override Mend org-injected dependencyDashboardApproval",
+      "matchPackageNames": ["*"],
+      "dependencyDashboardApproval": false
+    },
+    {
       "description": "Automerge devDependencies patch and minor",
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
真因: Mend がグローバルに {matchPackageNames:[*], dependencyDashboardApproval:true} を注入（job log で確認）。repo packageRule で後勝ち上書き。あわせて renovate:validate を ignore-scripts 方式に修正（CI=1 は TTY のビルド承認プロンプトを抑止できなかった）。Refs #30