### PR TITLE
docs: Astro 6.x 追随と ADR-0011/0012 追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ SRE/Platform Engineer 志望のアピールを兼ねた運用・IaC 重視構成
 
 ## Stack
 
-- **Framework**: Astro 5.x（React Islands は使用箇所限定）
+- **Framework**: Astro 6.x（React Islands は使用箇所限定）
 - **Language**: TypeScript 5（strict）
 - **CSS**: Tailwind v4（CSS-first config、`@theme` 使用）
 - **Content**: Astro Content Collections + MDX

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ SRE/Platform Engineer 志望のアピールを兼ねた運用・IaC 重視構成
 
 ## Stack
 
-- **Framework**: Astro 6.x（React Islands は使用箇所限定）
+- **Framework**: Astro 7.x（React Islands は使用箇所限定）
 - **Language**: TypeScript 5（strict）
 - **CSS**: Tailwind v4（CSS-first config、`@theme` 使用）
 - **Content**: Astro Content Collections + MDX

--- a/docs/adr/0011-astro-formatting-biome-only.md
+++ b/docs/adr/0011-astro-formatting-biome-only.md
@@ -1,0 +1,34 @@
+# ADR-0011: .astro フォーマッタを Biome に統一（Prettier 不採用）
+
+## Status
+
+Accepted (2026-05-28)
+
+## Context
+
+`.astro` ファイルの linter / formatter の扱いに、以下の 2 案があった:
+
+1. `.astro` を含め Biome 2.x に統一する（Astro template 部分は experimental）
+2. `.astro` のみ Prettier + prettier-plugin-astro を使い、他ファイルは別 linter に分ける
+
+Astro LSP は `Couldn't load prettier or prettier-plugin-astro` 警告を出すため、
+どちらの方針でもエディタ側の整合を取る必要がある。
+
+## Decision
+
+`.astro` を含め **Biome に統一**する（案 1）。Prettier + prettier-plugin-astro は導入しない。
+Astro template 部分が Biome 2.x で experimental であることは許容する。
+
+## Rationale
+
+- CLAUDE.md「ESLint・Prettier・Husky を導入しない」原則に合致する
+- 2 つのフォーマッタが境界条件で衝突するメンテコストの方が、experimental の整形揺れより重いと判断
+- SRE/Platform Engineer 志望のポートフォリオとして「設定統一・運用負債の最小化」を設計判断で示す狙い
+
+## Consequences
+
+- Astro template の整形は Biome 2.x の experimental 挙動に依存する
+- experimental の不便が **具体的に顕在化した時点で** 再評価する（それまでは本決定を尊重）
+- biome.json の Astro override は既設のため追加設定は不要
+- エディタ（nvim / conform / LSP formatting capability）側の設定は machine-specific のため
+  dotfiles で管理し、本 ADR の範囲外とする

--- a/docs/adr/0012-blog-hosted-externally.md
+++ b/docs/adr/0012-blog-hosted-externally.md
@@ -1,0 +1,30 @@
+# ADR-0012: ブログ記事は外部リポ / Zenn で管理し、/writing は index のみ
+
+## Status
+
+Accepted (2026-05-28)
+
+## Context
+
+ブログ記事の配置先として、以下の 2 案があった:
+
+1. 本リポの `src/content/writing/` MDX collection に記事本体を置く
+2. 記事本体は別リポ + 外部プラットフォームに置き、本サイトはリンク集に徹する
+
+## Decision
+
+- 記事本体は別リポ `takagiyuuki/blog`（Zenn CLI 管理）に置き、Zenn へ公開する（案 2）
+- 本リポの `/writing` は **外部 Zenn 記事の index のみ**とする
+  （タイトル・公開日・ジャンル・Zenn へのリンクを一覧表示。Zenn feed への RSS リンクは任意）
+
+## Rationale
+
+- Zenn を技術記事の主要プラットフォームとして使い、読者リーチを取るため
+- ポートフォリオサイトはコンテンツのホストではなく discovery surface と位置づける
+
+## Consequences
+
+- 本リポに `src/content/writing/` MDX collection は **作らない**
+- index の生成方式（Zenn RSS を build 時 parse / 手動 TS リスト / Zenn user API）は別途決定する
+- 「本サイトの運用そのものを書く ops docs」の置き場は本 ADR の対象外
+  （Zenn か、本リポ MDX co-located か未定。着手時にユーザーへ確認する）

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./node_modules/lefthook/schema.json
 pre-commit:
   commands:
     biome:


### PR DESCRIPTION
## 変更内容
- CLAUDE.md の Astro バージョン記述を 5.x → 6.x に更新（実インストールは v6.4.8）
- ADR-0011: .astro を Biome で整形、Prettier 不採用
- ADR-0012: ブログは別リポ/Zenn、/writing は index のみ

## 補足
- ADR-0001（stack selection）は選定時点の記録として 5.x のまま据え置き
- 上記2 ADR はエージェントメモリからの昇格