### PR TITLE
chore(biome): enable experimental full support for astro files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -27,7 +27,16 @@
       "!**/pnpm-lock.yaml"
     ]
   },
-  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "html": {
+    "experimentalFullSupportEnabled": true
+  },
   "javascript": {
     "formatter": {
       "quoteStyle": "single"
@@ -38,25 +47,8 @@
       "quoteStyle": "single"
     },
     "parser": {
-      "cssModules": true,
-      "tailwindDirectives": true
+      "cssModules": false,
+      "tailwindDirectives": false
     }
-  },
-  "overrides": [
-    {
-      "includes": ["src/**/*.astro"],
-      "linter": {
-        "rules": {
-          "style": {
-            "useConst": "off",
-            "useImportType": "off"
-          },
-          "correctness": {
-            "noUnusedVariables": "off",
-            "noUnusedImports": "off"
-          }
-        }
-      }
-    }
-  ]
+  }
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@
 pre-commit:
   commands:
     biome:
-      glob: "*.{js,ts,jsx,tsx,json,astro}"
+      glob: "*.{js,ts,jsx,tsx,json,jsonc,css,astro}"
       run: pnpm exec biome check --write --no-errors-on-unmatched {staged_files}
       stage_fixed: true
     astro-check:


### PR DESCRIPTION
## Summary

- Enable `html.experimentalFullSupportEnabled`, so Biome lints the template, `<style>` and `<script>` of `.astro` files
- Drop the `.astro` rule overrides, which are only needed while that flag is off
- Set `cssModules` / `tailwindDirectives` to false and widen the lefthook glob to `css` and `jsonc`

## Why

Biome only analysed the `---` frontmatter of `.astro`. Verified with a probe file: an unclosed tag, an unknown CSS property in `<style>` and `var` in `<script>` were all silently ignored. Since 2.3 the opt-in flag covers them, and 2.4 added HTML accessibility rules on top.

Removing the overrides is not incidental — the Biome docs recommend those four rules be disabled *only when* full support is off, because Biome cannot otherwise see that a component imported in the frontmatter is used in the template. With the flag on, keeping them would hide genuine unused variables.

`cssModules` was pointless (no `*.module.css` in the repo) and `tailwindDirectives` conflicts with ADR-0015, which rules out `@apply` / `@theme`. `global.css` passes with both disabled.

## Changes

- `biome.json` — add `html.experimentalFullSupportEnabled`, remove `overrides`, flip both CSS parser flags
- `lefthook.yml` — add `css` and `jsonc` to the pre-commit Biome glob

## Test plan

- [x] `pnpm exec biome check .` — 12 files, no errors
- [x] Probe `.astro` with errors in `<style>` and `<script>` is now reported
- [x] Removing the overrides produces no false positives on the real `src/` (verified both with and without the flag)

## Follow-ups

`html.formatter.enabled` is deliberately left off. It works, but reformats roughly 134 lines of `BaseLayout.astro` (void elements, attribute quoting, `<style>` indentation), so it belongs in its own commit.